### PR TITLE
Lower Perl version requirements to 5.8.1

### DIFF
--- a/lib/POSIX/strftime/Compiler.pm
+++ b/lib/POSIX/strftime/Compiler.pm
@@ -1,6 +1,6 @@
 package POSIX::strftime::Compiler;
 
-use 5.008004;
+use 5.008001;
 use strict;
 use warnings;
 use Carp;


### PR DESCRIPTION
Please lower Perl version requirement to 5.8.1. This ancient Perl works pretty well with POSIX::strftime::Compiler. This module is only reason that Plack won't start with this old Perl.

Thank you!
