### PR TITLE
microoptimization: check for invalid number of parameters later

### DIFF
--- a/lib/POSIX/strftime/Compiler.pm
+++ b/lib/POSIX/strftime/Compiler.pm
@@ -341,11 +341,11 @@ sub compile {
         }~;
     }
     my $code = q~sub {
+        ~ . $sprintf_code . q~
+        ~ . $need9char_code . q~
         if ( @_ != 9  && @_ != 6 ) {
             Carp::croak 'Usage: strftime(sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)';
         }
-        ~ . $sprintf_code . q~
-        ~ . $need9char_code . q~
         POSIX::strftime(q!~ . $posix_fmt . q~!,@_);
     }~;
     my $sub = eval $code; ## no critic


### PR DESCRIPTION
In the usual case (when providing six or nine parameters) a
condition less has to be checked.
