### PR TITLE
Test issues with space in perl path name

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -5,7 +5,7 @@ BEGIN {
     # Windows can't change timezone inside Perl script
     if (($ENV{TZ}||'') ne 'GMT') {
         $ENV{TZ} = 'GMT';
-        exec $^X, (map { "-I\"$_\"" } @INC), $0;
+        exec $^X (map { "-I\"$_\"" } @INC), $0;
     };
 }
 

--- a/t/02_timezone.t
+++ b/t/02_timezone.t
@@ -11,7 +11,7 @@ my $dir = dirname(__FILE__);
 my $found;
 for my $tz (qw( Europe/Paris CET-1CEST )) {
     $ENV{TZ} = $tz;
-    if (`$^X $inc $dir/02_timezone.pl %z 0 0 0 1 1 112` =~ /^\+0[12]00$/) {
+    if (`"$^X" $inc $dir/02_timezone.pl %z 0 0 0 1 1 112` =~ /^\+0[12]00$/) {
         $found = 1;
         last;
     };
@@ -27,7 +27,7 @@ else {
 my @t1 = (0, 0, 0, 1, 1, 112);
 my @t2 = (0, 0, 0, 1, 7, 112);
 
-is `$^X $inc $dir/02_timezone.pl %z @t1`, '+0100', "tmzone1($ENV{TZ})";
-is `$^X $inc $dir/02_timezone.pl %Z @t1`, 'CET',   "tmname1($ENV{TZ})";
-is `$^X $inc $dir/02_timezone.pl %z @t2`, '+0200', "tmzone2($ENV{TZ})";
-is `$^X $inc $dir/02_timezone.pl %Z @t2`, 'CEST',  "tmname2($ENV{TZ})";
+is `"$^X" $inc $dir/02_timezone.pl %z @t1`, '+0100', "tmzone1($ENV{TZ})";
+is `"$^X" $inc $dir/02_timezone.pl %Z @t1`, 'CET',   "tmname1($ENV{TZ})";
+is `"$^X" $inc $dir/02_timezone.pl %z @t2`, '+0200', "tmzone2($ENV{TZ})";
+is `"$^X" $inc $dir/02_timezone.pl %Z @t2`, 'CEST',  "tmname2($ENV{TZ})";


### PR DESCRIPTION
uses exec with indirect object syntax to avoid shell on Windows for 01_basic.t.
Quotes $^X in 02_timezone.t backtick calls.