### PR TITLE
fix indirect object notation for exec

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -2,10 +2,12 @@ use strict;
 use warnings;
 
 BEGIN {
-    # Windows can't change timezone inside Perl script
     if (($ENV{TZ}||'') ne 'GMT') {
         $ENV{TZ} = 'GMT';
-        exec $^X (map { "-I\"$_\"" } @INC), $0;
+        # Windows can't change timezone inside Perl script
+        if ($^O eq 'MSWin32') {
+            exec { $^X } map "\"$_\"", $^X, (map "-I$_", @INC), $0, @ARGV;
+        }
     };
 }
 

--- a/t/02_timezone.pl
+++ b/t/02_timezone.pl
@@ -4,10 +4,12 @@ use strict;
 use warnings;
 
 BEGIN {
-    # Windows can't change timezone inside Perl script
     if ($ENV{TEST_TZ}) {
         $ENV{TZ} = delete $ENV{TEST_TZ};
-        exec $^X (map { "-I\"$_\"" } @INC), $0, @ARGV;
+        # Windows can't change timezone inside Perl script
+        if ($^O eq 'MSWin32') {
+            exec { $^X } map "\"$_\"", $^X, (map "-I$_", @INC), $0, @ARGV;
+        }
     };
 }
 


### PR DESCRIPTION
On MacOS this distribution fails to install with errors like this:
````
perl: realpath couldn't resolve "-I"/home/me/.cpanm/work/12.3456/POSIX-strftime-Compiler-0.44/blib/arch""
````

As an example see this CPAN Testers report:
https://www.cpantesters.org/cpan/report/5454c4a8-dd98-11ea-8242-8735c0c62f6e

The breakage came from 9d52ce76a19b748b5db85428d67c564b92932b8e and was then copied further in 4aeb247d05e9249d1ff2bc111501b3ca39c398fd

This patch was incorrect because when given an indirect object, `exec` uses the first element from its argument list as the `$0` for the program being executed. The correct way to use `exec` with an indirect object is (generally) to repeat the value of the indirect object as the first element of the argument list for the `exec`. (This is all explained in detail in `perldoc -f exec`.)

The missing program name in the argument list was causing the first `-I"..."` switch to be used as the *name* of the `perl` process instead of as an argument. Then `perl` would call `realpath` on its name to figure out its exact path – but since the name is something with an `-I` in front and quotes embedded in it, `realpath` fails.

Just prepending `$^X` to the `exec` argument list fixes this and stops the tests from failing. But it does not make them correct. The embedded quotes in the `-I` switches are still a problem:

- On Unix-like OSs these quotes should not be embedded because when a program is run on this OS family it receives a list of arguments which do not need to be split further, and therefore programs take the value of an argument literally, including embedded quotes. Quoting is only correct for commands invoked through the shell (which requires joining the argument list into a single command string, which the shell must then parse back into a list, for which quotes are necessary as delimiters for values containing spaces).

- However, on Windows, programs are passed a single command string and the shell does very little interpreting. So programs do expect quotes in their arguments and they parse these quotes themselves.

The result is that in this regard, doing what is correct on Windows is broken on Unix, and vice versa.

Therefore, as the comments already mention that the `exec` is necessary only on Windows, the `exec` should be guarded to run only on Windows. This removes the conundrum with how to prepare arguments: since they only need to be prepared on Windows, the correct way is the Windows way.